### PR TITLE
Fix window DTO mapping null ID

### DIFF
--- a/api/MappingProfile.cs
+++ b/api/MappingProfile.cs
@@ -108,7 +108,15 @@ public class MappingProfile : Profile
             );
 
         CreateMap<WindowDto, Window>()
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => int.Parse(src.Id)))
+            .ForMember(
+                dest => dest.Id,
+                opt =>
+                    opt.MapFrom(src =>
+                        string.IsNullOrWhiteSpace(src.Id)
+                            ? 0
+                            : int.Parse(src.Id)
+                    )
+            )
             .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title))
             .ForMember(dest => dest.Start, opt => opt.MapFrom(src => src.Start))
             .ForMember(dest => dest.End, opt => opt.MapFrom(src => src.End))


### PR DESCRIPTION
## Summary
- avoid parsing null WindowDto.Id when creating Window entities

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840935cc4e883228ba1bdea5c1c3599